### PR TITLE
Rename to paymongo-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ NodeJS 8 or higher.
 Install the package with:
 
 ```sh
-npm install paymongo --save
+npm install paymongo-node --save
 # or
-yarn add paymongo
+yarn add paymongo-node
 ```
 
 ## Getting Started
@@ -27,7 +27,7 @@ yarn add paymongo
 Simple usage looks like:
 
 ```js
-const paymongo = require('paymongo')('your secret api key');
+const paymongo = require('paymongo-node')('your secret api key');
 
 paymongo.paymentIntents.create({
   amount: 10000,
@@ -52,7 +52,7 @@ paymongo.paymentIntents.create({
 Or `async`/`await`:
 
 ```js
-const paymongo = require('paymongo')('your secret api key');
+const paymongo = require('paymongo-node')('your secret api key');
 
 (async () => {
   try {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "paymongo",
+  "name": "paymongo-node",
   "version": "10.17.0",
   "description": "PayMongo API wrapper",
   "keywords": [
@@ -13,7 +13,7 @@
   "engines": {
     "node": "^8.1 || >=10.*"
   },
-  "main": "lib/paymongno.js",
+  "main": "src/paymongo.js",
   "devDependencies": {
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.5.0",


### PR DESCRIPTION
### What?

- Rename package name from `paymongo` to `paymongo-node`.

- To publish in npm since `paymongo` is already taken.

- Fix `package.json`